### PR TITLE
Display IBAN in human-readable DIN format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+YogaKnete (package: `de.yogaknete.app`) is a single-user Android app for yoga instructors to track classes and generate invoices. German-only UI. Offline-first with local Room database. The entire Android project lives under `android/`.
+
+## Build & Development Commands
+
+All commands run from the `android/` directory:
+
+```bash
+# Build
+gradle assembleDebug
+gradle assembleRelease        # requires keystore config
+
+# Tests
+gradle testDebugUnitTest      # unit tests (no instrumented tests)
+gradle test                   # all unit tests
+
+# Lint
+gradle lintDebug
+
+# Install on device
+gradle installDebug
+
+# Seed test data on device
+./scripts/seed-db.sh          # pushes seed JSON to device, then import via Datensicherung screen
+```
+
+**JDK requirement:** Use JDK 11–17. JDK 24+ breaks the Android test runner.
+
+## Architecture
+
+MVVM + Clean Architecture with Hilt DI. Single-Activity app (`MainActivity`) with Jetpack Compose Navigation.
+
+```
+android/app/src/main/java/de/yogaknete/app/
+├── core/           # DI modules (DatabaseModule, RepositoryModule), navigation, utilities
+├── data/           # Room DAOs, entities, repository implementations
+├── domain/         # Models, repository interfaces, services, use cases
+├── presentation/   # Compose screens + ViewModels, organized by feature
+└── ui/theme/       # Material 3 theme (Color, Type, Theme, Icons)
+```
+
+### Key patterns
+
+- **State**: ViewModels expose `StateFlow`, Compose collects via `collectAsState()`
+- **Data flow**: Screen → ViewModel → Repository (interface) → RepositoryImpl → Room DAO
+- **DI**: Hilt `@HiltViewModel` for ViewModels, `@Module`/`@Provides` with `SingletonComponent` for singletons
+- **Navigation**: String-based routes in `MainActivity` (`"week"`, `"invoices"`, `"invoice_detail/{invoiceId}"`, `"templates"`, `"profile_edit"`, `"studios"`, `"backup"`). Note: `core/navigation/Navigation.kt` is an older scaffold — actual navigation lives in `MainActivity.kt`
+- **Date/time**: Uses `kotlinx-datetime` (`LocalDate`, `LocalDateTime`), not `java.util.*`
+- **Serialization**: `kotlinx-serialization-json` for backup/restore (`BackupData` model)
+
+### Domain models
+
+- **YogaClass** — individual session with status (SCHEDULED/COMPLETED/CANCELLED) linked to a Studio
+- **Studio** — yoga studio with contact info and hourly rate
+- **Invoice** — monthly invoice per studio with payment status, PDF generation
+- **ClassTemplate** — recurring class definition for auto-scheduling
+- **UserProfile** — instructor's business info (name, address, tax ID, IBAN) used in invoice generation
+
+### Invoice generation pipeline
+
+`InvoiceHtmlGenerator` → HTML template (German) → iText7 PDF conversion (`InvoicePdfService`) → EPC QR code via ZXing (`EpcQrCodeGenerator`) embedded in PDF for SEPA bank transfers.
+
+
+## Testing
+
+Unit tests only (no UI instrumented tests). Located in `android/app/src/test/`. Uses JUnit 4 + MockK + kotlinx-coroutines-test. Tests cover models, repositories, ViewModels, date utilities, EPC QR generation, and invoice HTML generation.
+
+## CI/CD
+
+- **CI** (`.github/workflows/ci.yml`): lint → unit tests → debug APK on push/PR
+- **CD** (`.github/workflows/cd.yml`): signed release APK + AAB on tag push (`v*`)

--- a/android/app/src/main/java/de/yogaknete/app/core/utils/StringUtils.kt
+++ b/android/app/src/main/java/de/yogaknete/app/core/utils/StringUtils.kt
@@ -1,0 +1,37 @@
+package de.yogaknete.app.core.utils
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+
+/**
+ * Formats a string as IBAN in DIN format (groups of 4 separated by spaces).
+ * Example: "DE89370400440532013000" → "DE89 3704 0044 0532 0130 00"
+ */
+fun String.formatAsIban(): String = this.replace("\\s".toRegex(), "").chunked(4).joinToString(" ")
+
+/**
+ * VisualTransformation that displays IBAN input in DIN format (groups of 4 separated by spaces).
+ * The underlying value remains unformatted for storage.
+ */
+class IbanVisualTransformation : VisualTransformation {
+    override fun filter(text: AnnotatedString): TransformedText {
+        val formatted = text.text.formatAsIban()
+
+        return TransformedText(
+            AnnotatedString(formatted),
+            object : OffsetMapping {
+                override fun originalToTransformed(offset: Int): Int {
+                    val spacesBeforeOffset = offset / 4
+                    return (offset + spacesBeforeOffset).coerceAtMost(formatted.length)
+                }
+
+                override fun transformedToOriginal(offset: Int): Int {
+                    val spacesBeforeOffset = offset / 5
+                    return (offset - spacesBeforeOffset).coerceAtMost(text.text.length)
+                }
+            }
+        )
+    }
+}

--- a/android/app/src/main/java/de/yogaknete/app/domain/service/InvoiceHtmlGenerator.kt
+++ b/android/app/src/main/java/de/yogaknete/app/domain/service/InvoiceHtmlGenerator.kt
@@ -1,5 +1,6 @@
 package de.yogaknete.app.domain.service
 
+import de.yogaknete.app.core.utils.formatAsIban
 import de.yogaknete.app.domain.model.Invoice
 import de.yogaknete.app.domain.model.Studio
 import de.yogaknete.app.domain.model.UserProfile
@@ -469,7 +470,7 @@ class InvoiceHtmlGenerator @Inject constructor() {
             <div class="payment-details">
                 <p>Bitte überweisen Sie den Gesamtbetrag bis zum <strong>${dateFormat.format(dueDate)}</strong> auf folgendes Konto:</p>
                 ${if (userProfile.bankName.isNotEmpty()) "<p><strong>Bank:</strong> ${userProfile.bankName}</p>" else ""}
-                <p><strong>IBAN:</strong> ${formatIban(userProfile.iban)}</p>
+                <p><strong>IBAN:</strong> ${userProfile.iban.formatAsIban()}</p>
                 ${if (userProfile.bic.isNotEmpty()) "<p><strong>BIC:</strong> ${userProfile.bic}</p>" else ""}
                 <p><strong>Verwendungszweck:</strong> ${invoice.invoiceNumber}</p>
             </div>
@@ -480,7 +481,7 @@ class InvoiceHtmlGenerator @Inject constructor() {
     <div class="payment-footer">
         <div class="payment-footer-content">
             <div class="payment-footer-left">
-                IBAN: ${formatIban(userProfile.iban)}${if (userProfile.bic.isNotEmpty()) " &middot; BIC: ${userProfile.bic}" else ""}<br>
+                IBAN: ${userProfile.iban.formatAsIban()}${if (userProfile.bic.isNotEmpty()) " &middot; BIC: ${userProfile.bic}" else ""}<br>
                 Ref: ${invoice.invoiceNumber}
             </div>
             <div class="payment-footer-right">
@@ -502,10 +503,6 @@ class InvoiceHtmlGenerator @Inject constructor() {
         } else {
             "${h}h"
         }
-    }
-    
-    private fun formatIban(iban: String): String {
-        return iban.chunked(4).joinToString(" ")
     }
     
     private fun getMonthName(month: Int): String {

--- a/android/app/src/main/java/de/yogaknete/app/presentation/screens/invoice/InvoiceDetailScreen.kt
+++ b/android/app/src/main/java/de/yogaknete/app/presentation/screens/invoice/InvoiceDetailScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import de.yogaknete.app.core.utils.formatAsIban
 import de.yogaknete.app.domain.model.PaymentStatus
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
@@ -459,7 +460,7 @@ fun InvoiceDetailScreen(
                                     )
                                 }
                                 Text(
-                                    text = "IBAN: ${profile.iban}",
+                                    text = "IBAN: ${profile.iban.formatAsIban()}",
                                     style = MaterialTheme.typography.bodyMedium,
                                     fontWeight = FontWeight.Medium,
                                     color = MaterialTheme.colorScheme.onSecondaryContainer

--- a/android/app/src/main/java/de/yogaknete/app/presentation/screens/onboarding/UserProfileSetupScreen.kt
+++ b/android/app/src/main/java/de/yogaknete/app/presentation/screens/onboarding/UserProfileSetupScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import de.yogaknete.app.core.utils.IbanVisualTransformation
 import de.yogaknete.app.domain.model.UserProfile
 import de.yogaknete.app.ui.theme.YogaKneteTheme
 
@@ -288,8 +289,8 @@ fun UserProfileSetupScreen(
         
         OutlinedTextField(
             value = iban,
-            onValueChange = { 
-                iban = it.uppercase()
+            onValueChange = {
+                iban = it.replace(" ", "").uppercase()
                 ibanError = false
             },
             label = { Text("IBAN") },
@@ -301,7 +302,8 @@ fun UserProfileSetupScreen(
             } else {
                 { Text("Erforderlich für Überweisungen") }
             },
-            singleLine = true
+            singleLine = true,
+            visualTransformation = IbanVisualTransformation()
         )
         
         Spacer(modifier = Modifier.height(16.dp))

--- a/android/app/src/main/java/de/yogaknete/app/presentation/screens/settings/UserProfileEditScreen.kt
+++ b/android/app/src/main/java/de/yogaknete/app/presentation/screens/settings/UserProfileEditScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import de.yogaknete.app.core.utils.IbanVisualTransformation
 import de.yogaknete.app.domain.model.UserProfile
 import kotlinx.coroutines.launch
 
@@ -318,8 +319,8 @@ fun UserProfileEditScreen(
                 
                 OutlinedTextField(
                     value = iban,
-                    onValueChange = { 
-                        iban = it.uppercase()
+                    onValueChange = {
+                        iban = it.replace(" ", "").uppercase()
                         ibanError = false
                     },
                     label = { Text("IBAN") },
@@ -328,7 +329,8 @@ fun UserProfileEditScreen(
                     supportingText = if (ibanError) {
                         { Text("Bitte gib eine gültige IBAN ein") }
                     } else null,
-                    singleLine = true
+                    singleLine = true,
+                    visualTransformation = IbanVisualTransformation()
                 )
                 
                 Spacer(modifier = Modifier.height(16.dp))

--- a/android/app/src/test/java/de/yogaknete/app/core/utils/StringUtilsTest.kt
+++ b/android/app/src/test/java/de/yogaknete/app/core/utils/StringUtilsTest.kt
@@ -1,0 +1,106 @@
+package de.yogaknete.app.core.utils
+
+import androidx.compose.ui.text.AnnotatedString
+import org.junit.Test
+import org.junit.Assert.*
+
+/**
+ * Tests for StringUtils - string formatting helper functions
+ */
+class StringUtilsTest {
+
+    @Test
+    fun `formatAsIban formats German IBAN correctly`() {
+        val iban = "DE89370400440532013000"
+
+        val formatted = iban.formatAsIban()
+
+        assertEquals("DE89 3704 0044 0532 0130 00", formatted)
+    }
+
+    @Test
+    fun `formatAsIban handles short string`() {
+        val short = "DE89"
+
+        val formatted = short.formatAsIban()
+
+        assertEquals("DE89", formatted)
+    }
+
+    @Test
+    fun `formatAsIban handles empty string`() {
+        val empty = ""
+
+        val formatted = empty.formatAsIban()
+
+        assertEquals("", formatted)
+    }
+
+    @Test
+    fun `formatAsIban strips existing spaces before formatting`() {
+        val iban = "DE89 2385 8444 8353 4128 57"
+
+        val formatted = iban.formatAsIban()
+
+        assertEquals("DE89 2385 8444 8353 4128 57", formatted)
+    }
+
+    @Test
+    fun `formatAsIban handles partial group at end`() {
+        val iban = "DE8937040044053201300" // 21 chars, last group has 1 char
+
+        val formatted = iban.formatAsIban()
+
+        assertEquals("DE89 3704 0044 0532 0130 0", formatted)
+    }
+
+    @Test
+    fun `IbanVisualTransformation formats text correctly`() {
+        val transformation = IbanVisualTransformation()
+        val input = AnnotatedString("DE89370400440532013000")
+
+        val result = transformation.filter(input)
+
+        assertEquals("DE89 3704 0044 0532 0130 00", result.text.text)
+    }
+
+    @Test
+    fun `IbanVisualTransformation handles empty input`() {
+        val transformation = IbanVisualTransformation()
+        val input = AnnotatedString("")
+
+        val result = transformation.filter(input)
+
+        assertEquals("", result.text.text)
+    }
+
+    @Test
+    fun `IbanVisualTransformation originalToTransformed maps correctly`() {
+        val transformation = IbanVisualTransformation()
+        val input = AnnotatedString("DE89370400440532013000")
+        val result = transformation.filter(input)
+        val offsetMapping = result.offsetMapping
+
+        // Position 0 (D) -> 0
+        assertEquals(0, offsetMapping.originalToTransformed(0))
+        // Position 4 (3) -> 5 (after first space)
+        assertEquals(5, offsetMapping.originalToTransformed(4))
+        // Position 8 (0) -> 10 (after second space)
+        assertEquals(10, offsetMapping.originalToTransformed(8))
+    }
+
+    @Test
+    fun `IbanVisualTransformation transformedToOriginal maps correctly`() {
+        val transformation = IbanVisualTransformation()
+        val input = AnnotatedString("DE89370400440532013000")
+        val result = transformation.filter(input)
+        val offsetMapping = result.offsetMapping
+
+        // Position 0 (D) -> 0
+        assertEquals(0, offsetMapping.transformedToOriginal(0))
+        // Position 5 (3, after space) -> 4
+        assertEquals(4, offsetMapping.transformedToOriginal(5))
+        // Position 10 (0, after second space) -> 8
+        assertEquals(8, offsetMapping.transformedToOriginal(10))
+    }
+}


### PR DESCRIPTION
## Summary
- Format IBANs with spaces every 4 characters (e.g. `DE89 3704 0044 0532 0130 00`)
- Add `IbanVisualTransformation` for auto-formatting in input fields as users type
- Apply consistent formatting across invoice detail screen, PDF generation, profile edit, and onboarding screens

## Test plan
- [x] Unit tests for `formatAsIban()` extension and `IbanVisualTransformation`
- [x] Open invoice detail screen → verify IBAN shows with spaces
- [x] Generate a PDF → verify IBAN still formatted correctly
- [x] Edit profile → verify IBAN input auto-formats while typing
- [x] Go through onboarding → verify IBAN input auto-formats while typing