### PR TITLE
Improve ClassActionDialog and add app guidelines

### DIFF
--- a/android/app/src/main/java/de/yogaknete/app/presentation/screens/week/WeekViewDialogs.kt
+++ b/android/app/src/main/java/de/yogaknete/app/presentation/screens/week/WeekViewDialogs.kt
@@ -258,11 +258,13 @@ fun ClassActionDialog(
     onEdit: () -> Unit,
     onDelete: () -> Unit
 ) {
+    var showDeleteConfirmDialog by remember { mutableStateOf(false) }
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = {
             Text(
-                text = "Kurs abschließen?",
+                text = "Kurs-Aktionen",
                 style = MaterialTheme.typography.headlineSmall
             )
         },
@@ -413,24 +415,22 @@ fun ClassActionDialog(
                         }
                     }
                     
-                    // Delete option for completed or cancelled classes
-                    if (yogaClass.status != ClassStatus.SCHEDULED) {
-                        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-                        TextButton(
-                            onClick = onDelete,
-                            colors = ButtonDefaults.textButtonColors(
-                                contentColor = MaterialTheme.colorScheme.error
-                            ),
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Delete,
-                                contentDescription = null,
-                                modifier = Modifier.size(18.dp)
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text("Kurs löschen")
-                        }
+                    // Delete option
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                    TextButton(
+                        onClick = { showDeleteConfirmDialog = true },
+                        colors = ButtonDefaults.textButtonColors(
+                            contentColor = MaterialTheme.colorScheme.error
+                        ),
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Kurs löschen")
                     }
                 }
             }
@@ -442,6 +442,38 @@ fun ClassActionDialog(
             }
         }
     )
+
+    if (showDeleteConfirmDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirmDialog = false },
+            title = { Text("Kurs löschen?") },
+            text = {
+                Text(
+                    "Möchtest du \"${yogaClass.title}\" " +
+                    "(${DateUtils.formatDayDate(yogaClass.startTime.date)}) " +
+                    "wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden."
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDeleteConfirmDialog = false
+                        onDelete()
+                    },
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error
+                    )
+                ) {
+                    Text("Löschen")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirmDialog = false }) {
+                    Text("Abbrechen")
+                }
+            }
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/android/docs/architecture-guidelines.md
+++ b/android/docs/architecture-guidelines.md
@@ -1,0 +1,130 @@
+# Architecture Guidelines — YogaKnete
+
+Overview of existing patterns and conventions in the codebase.
+
+---
+
+## 1. Layered Architecture
+
+MVVM + Clean Architecture in three layers:
+
+- **presentation/** — UI (Compose screens) + ViewModels
+- **domain/** — Models, repository interfaces, use cases, services
+- **data/** — Room DAOs, repository implementations
+
+### Dependency Rule
+- presentation may import domain, but never data
+- domain imports nothing from presentation or data — pure Kotlin interfaces and models
+- data implements the domain interfaces
+
+### Feature Organization
+Each feature gets its own directory under `presentation/screens/` with its own ViewModel, screen composable, and optional dialogs. Shared UI building blocks live in `presentation/components/`.
+
+---
+
+## 2. State Management
+
+### Pattern
+- ViewModels hold state as `MutableStateFlow` (private) + `StateFlow` (public)
+- Screens collect state via `collectAsState()`
+- State updates always via `_state.update { it.copy(...) }`
+
+### Naming Conventions
+- State class: `<Feature>UiState` or `<Feature>ViewState`
+- Private flow: `_state` or `_uiState`
+- Public flow: `state` or `uiState`
+
+---
+
+## 3. Data Flow
+
+```
+UI tap → Screen → ViewModel → Repository (interface) → RepositoryImpl → Room DAO
+         ← StateFlow ← Flow ← DAO query
+```
+
+### Repository Pattern
+- domain/ defines repository interfaces (pure Kotlin)
+- data/ implements these interfaces, delegating to Room DAOs
+- Reactive reads as Flow, one-shot reads and writes as suspend
+- New features should go through repository interfaces, not directly to DAOs
+
+---
+
+## 4. Dependency Injection (Hilt)
+
+- **DatabaseModule** — provides Room database and DAOs
+- **RepositoryModule** — binds repository interfaces to implementations
+- Both as singletons (SingletonComponent)
+- ViewModels with `@HiltViewModel` + `@Inject constructor`
+- In Compose via `hiltViewModel()`
+- ViewModels receive interfaces, never implementations
+
+---
+
+## 5. Dialog State: ViewModel vs. Local
+
+| ViewModel state | Local composable state |
+|----------------|------------------------|
+| Dialog visibility | Confirmation dialogs ("Are you sure?") |
+| Selected element | Dropdown menu expanded/collapsed |
+| Form dialogs | Temporary UI toggles |
+
+**Rule of thumb:** Does the state affect business logic or need to be shared across composables? → ViewModel. Is it a pure UI intermediate step? → Local state.
+
+---
+
+## 6. Navigation
+
+Single-activity app with Jetpack Compose Navigation:
+- String-based routes in MainActivity
+- Navigation callbacks passed as lambdas to screens
+- Back navigation via `navController.navigateUp()`
+
+---
+
+## 7. Date & Time
+
+Exclusively **kotlinx-datetime**, never java.util.Date or java.time:
+
+| Type | Usage |
+|------|-------|
+| LocalDate | Days, weekdays, invoice periods |
+| LocalDateTime | Class times (start, end) |
+| LocalTime | Times in templates |
+
+Helper class `DateUtils` in core/utils/ for formatting and calculations.
+
+---
+
+## 8. Serialization
+
+- kotlinx-serialization-json for backup/restore
+- Domain models annotated with @Serializable
+- Purely offline, no networking
+
+---
+
+## 9. Test Strategy
+
+- **Unit tests only** — no UI/instrumented tests
+- Framework: JUnit 4 + MockK + kotlinx-coroutines-test
+- ViewModels constructed manually (no Hilt in tests)
+- StandardTestDispatcher + Dispatchers.setMain() for coroutine tests
+- Test names as backtick strings
+
+### What is tested
+ViewModels (state changes, actions), repositories (DAO delegation), models (calculations), utils (formatting), services (HTML/PDF/QR), use cases (auto-scheduling)
+
+---
+
+## 10. Core Rules
+
+1. New features → own directory under presentation/screens/, own ViewModel
+2. Data flow → always through repository interface
+3. State → MutableStateFlow + update { it.copy(...) }
+4. DI → @HiltViewModel, bind interfaces in RepositoryModule
+5. Dialogs → visibility in ViewModel state, confirmations as local state
+6. Date/time → kotlinx-datetime, never java.util
+7. Tests → JUnit 4, MockK, construct ViewModels manually
+8. Language → German UI labels, English code comments

--- a/android/docs/design-guidelines.md
+++ b/android/docs/design-guidelines.md
@@ -1,0 +1,119 @@
+# Design Guidelines — YogaKnete
+
+Visual guidelines for consistent UI components and dialogs.
+
+---
+
+## 1. Color System
+
+### Theme
+Purple-based Material 3 theme with light and dark variants.
+
+### Status Colors
+
+| Status | Color | Container | Icon style |
+|--------|-------|-----------|------------|
+| SCHEDULED | onSurfaceVariant | surfaceVariant | Outlined |
+| COMPLETED | primary | primaryContainer | Filled |
+| CANCELLED | error | errorContainer | Filled |
+
+**Rules:**
+- Always use `MaterialTheme.colorScheme`, never hardcoded colors
+- Semantic colors (YogaSuccess, YogaError) only for HTML generation, not in Compose
+
+### Selected State
+
+- **Active:** Container alpha 0.6 + border (2dp) + bold + checkmark icon
+- **Inactive:** Container alpha 0.15, no border, normal font weight
+
+---
+
+## 2. Components
+
+### Dialog Types
+
+| Type | When |
+|------|------|
+| AlertDialog | Action selection, confirmations, short forms |
+| Dialog + Card | Complex forms with TopAppBar (X left, Save right) |
+
+### Cards as Action Buttons
+For selectable actions (status buttons), use Card with onClick:
+- Icon left, action text center, checkmark right (when active)
+- Container color by status with alpha transparency
+- Border only in active state
+
+### Destructive Actions
+- Always visually separated by HorizontalDivider
+- TextButton with error color, never as Card
+- Icon (18dp) + text combined
+
+### Standard Buttons
+- Confirm: right side of dialog
+- Cancel: left side of dialog
+- Form dialogs: Save in TopAppBar
+
+---
+
+## 3. Icons
+
+| Concept | Icon | Style |
+|---------|------|-------|
+| Completed | CheckCircle / CheckCircleOutline | Filled / Outlined |
+| Cancelled | Cancel | Filled |
+| Edit | Edit | Filled |
+| Delete | Delete | Filled |
+| Close | Close | Filled |
+| Add | Add | Filled |
+| Date | Event | Outlined |
+| Time | Schedule | Outlined |
+
+**Rules:**
+- Filled for active states and primary actions
+- Outlined for inactive states and secondary info
+- Icon tint follows semantics: primary (positive), error (negative), onSurfaceVariant (neutral)
+
+---
+
+## 4. Spacing
+
+| Element | Value |
+|---------|-------|
+| Between groups | 16dp |
+| Within groups | 8dp |
+| Card inner padding | 12–16dp |
+| Icon to text | 16dp (cards), 8dp (buttons) |
+| Divider padding | 8dp vertical |
+| Form fields | 16dp spacing |
+
+---
+
+## 5. Typography
+
+| Level | Style | Usage |
+|-------|-------|-------|
+| Dialog title | headlineSmall | Main heading |
+| Section header | titleMedium + Bold | Form sections |
+| Action text | titleMedium | Card buttons |
+| Details | bodyMedium | Descriptions, info |
+| Hint/caption | bodySmall + 0.7 alpha | Timestamps, hints |
+
+---
+
+## 6. Visual Hierarchy for Actions
+
+Three tiers in dialogs:
+
+1. **Primary actions** — Colored cards with status semantics (top)
+2. **Secondary actions** — Neutral cards in surfaceVariant (middle)
+3. **Destructive actions** — HorizontalDivider + TextButton in error color (bottom)
+
+---
+
+## 7. General Rules
+
+- No hardcoded colors — always use MaterialTheme
+- Alpha values: 0.15 (inactive), 0.3 (neutral), 0.6 (active)
+- German labels in UI, English comments in code
+- HorizontalDivider only between action groups, never between equivalent actions
+- Selection state always communicated via 3 signals: border + bold + checkmark

--- a/android/docs/ux-guidelines.md
+++ b/android/docs/ux-guidelines.md
@@ -1,0 +1,81 @@
+# UX Guidelines — YogaKnete
+
+Practical UX rules for dialogs, actions, and interaction patterns.
+Based on Material Design 3 and established patterns in the project.
+
+---
+
+## 1. Dialog Types
+
+| Type | When to use |
+|------|-------------|
+| **AlertDialog** | Confirmations (yes/no), simple forms (2–4 fields), info dialogs |
+| **Full-screen Dialog** | Complex forms with 5+ fields and scrolling |
+
+**Decision guide:**
+- Confirmation or short form? → AlertDialog
+- Form with 5+ fields? → Full-screen Dialog with TopAppBar (X + Save)
+
+**Rules:**
+- AlertDialog: Max 2 buttons — Cancel (left) + Confirm (right)
+- Full-screen Dialog: Close icon (X) left, Save button right in TopAppBar
+
+---
+
+## 2. Dialog Titles
+
+| Context | Title form | Example |
+|---------|-----------|---------|
+| Confirmation/decision | Question | "Studio löschen?" |
+| Create new element | Noun | "Neuer Yoga-Kurs" |
+| Edit element | Verb + object | "Kurs bearbeiten" |
+| Action menu | Neutral label | "Kurs-Aktionen" |
+| Info/statistics | Descriptive | "Wochenübersicht" |
+
+- Title must match **all** available actions in the dialog
+- User should understand what happens from title + buttons alone
+- No generic titles like "Warnung" or "Achtung"
+
+---
+
+## 3. Destructive Actions (Delete)
+
+### Visibility
+- Delete is **always visible** — never hidden behind state conditions
+- Position: End of action list, visually separated by divider
+- Color: Icon and text in error color
+
+### Confirmation
+Every destructive, irreversible action **must** have a confirmation dialog:
+- Title: "[Element] löschen?"
+- Text: "Möchtest du [concrete name] wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden."
+- Confirm button in error color with concrete verb ("Löschen")
+- Cancel button
+
+---
+
+## 4. Action Grouping
+
+Group actions by category, with dividers between groups:
+
+1. **Primary actions** — most frequent first (e.g., status changes)
+2. **Secondary actions** — edit, reschedule
+3. **Destructive actions** — always last, visually separated
+
+### Dialog Buttons
+- Max 2 buttons: Cancel (left) + Confirm (right)
+- Destructive confirmations in error color
+- Button text = concrete verb ("Löschen", "Speichern") — never "OK" or "Ja"
+
+---
+
+## 5. Checklist for New Dialogs
+
+- [ ] Correct dialog type? (AlertDialog / Full-screen)
+- [ ] Title matches all available actions?
+- [ ] Max 2 buttons for AlertDialog?
+- [ ] Button text = concrete verb?
+- [ ] Destructive actions at the end, separated by divider?
+- [ ] Destructive actions in error color?
+- [ ] Confirmation dialog for irreversible actions?
+- [ ] Confirmation text names concrete element + consequence?


### PR DESCRIPTION
## Summary
- **Rename dialog title** from "Kurs abschließen?" to "Kurs-Aktionen" — neutral title that matches all available actions
- **Always show delete button** regardless of class status (previously hidden for SCHEDULED classes)
- **Add delete confirmation dialog** with error-colored confirm button and warning text, following the existing StudiosManagementScreen pattern
- **Add app-wide guidelines** for UX, visual design, and architecture in `android/docs/`

## Test plan
- [x] Open week view, tap a SCHEDULED class → "Kurs löschen" should now be visible
- [x] Tap "Kurs löschen" → confirmation dialog should appear
- [x] Cancel confirmation → returns to action dialog, class not deleted
- [x] Confirm deletion → class is deleted
- [x] Tap "Durchgeführt"/"Ausgefallen"/"Bearbeiten" → works as before
- [x] Verify existing unit tests still pass